### PR TITLE
Add precompiler output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Handlebars Plugin for DocPad
 Adds support for the [Handlebars](http://handlebarsjs.com/) templating engine to [DocPad](https://docpad.org)
 
-Convention:  `.anything.handlebars|hbs|hb`
+Convention:  `.inlinejs|js|anything.handlebars|hbs|hb`
 
 
 ## Install
@@ -28,6 +28,36 @@ Here is a small example:
           partials:
             title: '<h1>{{document.title}}</h1>'
             goUp: '<a href="#">Scroll up</a>'
+    }
+
+
+## Usage as precompiler
+
+If the document extension is `.inlinejs|js.handlebars|hbs|hb`, the plugin will produce a precompiled template.
+In that, case, you can customise the ouput in the docpad settings:
+
+    {
+        precompileOpts:
+            wrapper: "default"
+                # wrapper should be "default", "amd" or "none" (please note that "none" is probably not what you want
+                # "none": This option produces non-uglifable, so use "*.inlinejs.handlebars" extension
+                #     function (Handlebars,depth0,helpers,partials,data) {
+                #         ...
+                #     }
+                # "default" :
+                #     (function() {
+                #         var template = Handlebars.template, templates = Handlebars.templates = Handlebars.templates || {};
+                #         templates['test'] = template(function (Handlebars,depth0,helpers,partials,data) {
+                #             ...
+                #         })
+                #     })();
+                # "amd":
+                #     define(['handlebars'], function(Handlebars) {
+                #         var template = Handlebars.template, templates = Handlebars.templates = Handlebars.templates || {};
+                #         templates['test'] = template(function (Handlebars,depth0,helpers,partials,data) {
+                #             ...
+                #         });
+                #     });
     }
 
 


### PR DESCRIPTION
This patch permits the docpad-plugin-handlebars to output javascript precompiled templates
