### PR TITLE
v2.5.1 - update plugin for 6.82.x line of DocPad

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,48 +1,57 @@
 {
   "name": "docpad-plugin-handlebars",
-  "version": "2.4.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "accepts": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-      "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+    "@bevry/pluginloader": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@bevry/pluginloader/-/pluginloader-1.1.2.tgz",
+      "integrity": "sha512-EgSMNx7HyalYXzuk+ciPKBv+OhgwJWnSjbDnDaxybjuysCKlLTMTLhHrR7pCDyakXHYi7XCq57SDxMpdo3WGAQ==",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.6",
-        "negotiator": "0.5.3"
+        "editions": "^2.0.2",
+        "errlop": "^1.0.3",
+        "semver": "^5.5.1",
+        "typechecker": "^4.6.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
+          }
+        }
       }
     },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
-      "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
     },
     "ambi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
-      "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ambi/-/ambi-3.2.0.tgz",
+      "integrity": "sha512-nj5sHLPFd7u2OLmHdFs4DHt3gK6edpNw35hTRIKyI/Vd2Th5e4io50rw1lhmCdUNO2Mm4/4FkHmv6shEANAWcw==",
       "dev": true,
       "requires": {
-        "editions": "^1.1.1",
+        "editions": "^2.1.0",
         "typechecker": "^4.3.0"
       },
       "dependencies": {
-        "typechecker": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz",
-          "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
           "dev": true,
           "requires": {
-            "editions": "^1.3.4"
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
           }
         }
       }
@@ -52,6 +61,12 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "optional": true
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -86,41 +101,22 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+    "assert-helpers": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/assert-helpers/-/assert-helpers-4.5.1.tgz",
+      "integrity": "sha512-OatrgrHqVW/rFrkRwTLsPsxGkLBRMn3LIEjnYmT7xgJGWo4GKpI4dnwFUOu8IoVhC8TkJ0Za7LuRyXZTrdqEEw==",
+      "dev": true,
+      "requires": {
+        "ansicolors": "^0.3.2",
+        "diff": "^3.2.0",
+        "editions": "^1.3.3"
+      }
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-      "dev": true
+      "version": "0.2.10",
+      "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+      "optional": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -158,6 +154,14 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
@@ -174,6 +178,14 @@
         "lodash": "^4.17.4",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "babel-helper-call-delegate": {
@@ -655,54 +667,92 @@
       "dev": true
     },
     "backbone": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.3.tgz",
-      "integrity": "sha1-wiz9B/yG676uYdGJKe0RXpmdZbk=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
+      "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
       "dev": true,
       "requires": {
-        "underscore": ">=1.7.0"
+        "underscore": ">=1.8.3"
       }
     },
     "badges": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/badges/-/badges-1.2.4.tgz",
-      "integrity": "sha1-jHts1k/3GrvAZpcvAtWdxCc/H5A=",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/badges/-/badges-1.2.9.tgz",
+      "integrity": "sha512-Js5e+qLOb/uOKIfrJsEWZfYQoyfKTBMd9ZAk8KbOR77UxzCgeA9RAPrHSjEYB8V0eV+agKPIcB+QqPLpcgBXyg==",
       "dev": true,
       "requires": {
-        "editions": "^1.3.3"
+        "editions": "^2.1.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
+          }
+        }
       }
     },
     "bal-util": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-2.5.1.tgz",
-      "integrity": "sha1-m3ammwG8GquB4NkXuuIhbxYtjXI=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-2.8.0.tgz",
+      "integrity": "sha512-4krTXfpVnB1IOVBHqu8S86GrWJOd7hRts/nruO/GrhlPrVYwyOW8tHSjY2TbytZ4oVoKJXU8chaW+C0bnBiwjw==",
       "dev": true,
       "requires": {
-        "ambi": "^2.2.0",
-        "eachr": "^2.0.2",
-        "extendr": "^2.1.0",
-        "extract-opts": "^2.2.0",
-        "ignorefs": "^1.0.0",
-        "safefs": "^3.1.2",
+        "ambi": "^2.5.0",
+        "eachr": "^3.2.0",
+        "editions": "^1.3.4",
+        "extendr": "^3.2.2",
+        "extract-opts": "^3.3.1",
+        "ignorefs": "^1.1.1",
+        "safefs": "^4.1.0",
         "scandirectory": "^2.5.0",
-        "taskgroup": "^4.0.5",
-        "typechecker": "^2.0.8"
+        "taskgroup": "^5.0.1",
+        "typechecker": "^4.3.0"
       },
       "dependencies": {
-        "extract-opts": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz",
-          "integrity": "sha1-H6KOunNSxttID4hc63GkaBC+bX0=",
+        "ambi": {
+          "version": "2.5.0",
+          "resolved": "http://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
+          "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
           "dev": true,
           "requires": {
-            "typechecker": "~2.0.1"
+            "editions": "^1.1.1",
+            "typechecker": "^4.3.0"
+          }
+        },
+        "scandirectory": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-2.5.0.tgz",
+          "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
+          "dev": true,
+          "requires": {
+            "ignorefs": "^1.0.0",
+            "safefs": "^3.1.2",
+            "taskgroup": "^4.0.5"
           },
           "dependencies": {
-            "typechecker": {
-              "version": "2.0.8",
-              "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-              "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4=",
-              "dev": true
+            "safefs": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/safefs/-/safefs-3.2.2.tgz",
+              "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "*"
+              }
+            },
+            "taskgroup": {
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-4.3.1.tgz",
+              "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
+              "dev": true,
+              "requires": {
+                "ambi": "^2.2.0",
+                "csextends": "^1.0.3"
+              }
             }
           }
         }
@@ -714,86 +764,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64-url": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-      "integrity": "sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg=",
-      "dev": true
-    },
-    "basic-auth": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
-      "integrity": "sha1-Awk1sB3nyblKgksp8/zLdQ06UpA=",
-      "dev": true
-    },
-    "basic-auth-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-      "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI=",
-      "dev": true
-    },
-    "batch": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-      "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
-      "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "binaryextensions": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.1.tgz",
-      "integrity": "sha1-HmN0iLNbWL2l9HdL+WpSEqjJB1U=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
+      "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg==",
       "dev": true
-    },
-    "body-parser": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
-      "integrity": "sha1-wIzzMMM1jhUQFqBXRvE/ApyX+pc=",
-      "dev": true,
-      "requires": {
-        "bytes": "2.1.0",
-        "content-type": "~1.0.1",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "http-errors": "~1.3.1",
-        "iconv-lite": "0.4.11",
-        "on-finished": "~2.3.0",
-        "qs": "4.0.0",
-        "raw-body": "~2.1.2",
-        "type-is": "~1.6.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.11",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
-          "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -805,130 +780,97 @@
         "concat-map": "0.0.1"
       }
     },
-    "bytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
-      "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q=",
-      "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
-    },
-    "caterpillar": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/caterpillar/-/caterpillar-2.0.9.tgz",
-      "integrity": "sha1-OVj36lU9OPz0iY12RYbfe8Eyvp4=",
+    "cac": {
+      "version": "5.0.16",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-5.0.16.tgz",
+      "integrity": "sha512-QHPtQCPvzqtTkcdrRAcylHJWa48zvBdQVDdutMgIL70CHiyQ6WmKh9ZYJZXSk3lq6sE2K7y92xItXFO1Bk892A==",
       "dev": true,
       "requires": {
-        "extendr": "^2.1.0",
-        "readable-stream": "^1.0.33"
-      }
-    },
-    "caterpillar-filter": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/caterpillar-filter/-/caterpillar-filter-2.0.3.tgz",
-      "integrity": "sha1-8/w14/VQjqII+XrVSpvBXqbWbyk=",
-      "dev": true
-    },
-    "caterpillar-human": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/caterpillar-human/-/caterpillar-human-2.1.2.tgz",
-      "integrity": "sha1-IzCN3GqAG+mKdRsj5p9ghp17hgM=",
-      "dev": true,
-      "requires": {
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.1"
-      }
-    },
-    "chainy-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/chainy-core/-/chainy-core-1.6.0.tgz",
-      "integrity": "sha1-9E1KE6QBcfsV6Lz1zb+t9FV2GSk=",
-      "dev": true,
-      "requires": {
-        "csextends": "^1.0.3",
-        "taskgroup": "^4.3.1 || ^5.0.0"
-      }
-    },
-    "chainy-plugin-each": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/chainy-plugin-each/-/chainy-plugin-each-1.1.0.tgz",
-      "integrity": "sha1-glJBg6Ln+sf7pE/opxznSapczcY=",
-      "dev": true,
-      "requires": {
-        "taskgroup": "5"
+        "chalk": "^2.4.1",
+        "joycon": "^2.1.2",
+        "minimost": "^1.2.0",
+        "redent": "^2.0.0",
+        "string-width": "^2.1.1",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
-        "eachr": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
-          "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "editions": "^1.1.1",
-            "typechecker": "^4.3.0"
+            "color-convert": "^1.9.0"
           }
         },
-        "extendr": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/extendr/-/extendr-3.3.0.tgz",
-          "integrity": "sha512-BmBSu+KOX2XOo3XMECiekGY8VAr3O4aGYgOaHQDNg2ez5rOYW+SDfNStao4VNzr+6N27Vw3A7HJKJMrHmAAXvQ==",
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "editions": "^1.3.3",
-            "typechecker": "^4.4.1"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
-        "taskgroup": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-5.0.1.tgz",
-          "integrity": "sha1-CHNsmyRoOxQ0d0Ix60tzqnw/ebU=",
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "ambi": "^2.5.0",
-            "eachr": "^3.2.0",
-            "editions": "^1.1.1",
-            "extendr": "^3.2.0"
-          }
-        },
-        "typechecker": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz",
-          "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.4"
+            "has-flag": "^3.0.0"
           }
         }
       }
     },
-    "chainy-plugin-feed": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chainy-plugin-feed/-/chainy-plugin-feed-1.0.0.tgz",
-      "integrity": "sha1-GvUyyzgk6HVjnFX9A1Ko38HNA3w=",
+    "caterpillar": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/caterpillar/-/caterpillar-3.1.2.tgz",
+      "integrity": "sha512-180KtSnfAFdRGjbO4nUBFdIBtj2D2cEOT5ddwAmFsCR3mIsAMKLti2fiavrIfPZR7vqNZhCZbCCLKxFmV2VemA==",
       "dev": true,
       "requires": {
-        "feedr": "^2.9.0"
+        "editions": "^2.0.2",
+        "extendr": "^3.2.0",
+        "rfc-log-levels": "^1.0.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
+          }
+        }
       }
     },
-    "chainy-plugin-map": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/chainy-plugin-map/-/chainy-plugin-map-1.0.5.tgz",
-      "integrity": "sha1-ltjF9h7nmRTrNXS/7TsWWdERiBM=",
-      "dev": true
+    "caterpillar-filter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caterpillar-filter/-/caterpillar-filter-3.0.0.tgz",
+      "integrity": "sha1-WDOMJpwhB0AmuAPQUmi0DwL52IE=",
+      "dev": true,
+      "requires": {
+        "editions": "^1.1.1"
+      }
     },
-    "chainy-plugin-set": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/chainy-plugin-set/-/chainy-plugin-set-1.0.2.tgz",
-      "integrity": "sha1-9EV53Keqk8U+Pd0TCALgjYJA8Ec=",
-      "dev": true
+    "caterpillar-human": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caterpillar-human/-/caterpillar-human-3.0.0.tgz",
+      "integrity": "sha1-PcytsXL7fuifjSo1skdc0/FaFXo=",
+      "dev": true,
+      "requires": {
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "editions": "^1.1.1"
+      }
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -939,10 +881,40 @@
         "supports-color": "^2.0.0"
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+      "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ansi-regex": "^2.1.1",
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.14",
+        "timers-ext": "^0.1.5"
+      }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "coffeelint": {
@@ -957,82 +929,46 @@
         "optimist": "^0.6.1",
         "resolve": "^0.6.3",
         "strip-json-comments": "^1.0.2"
+      },
+      "dependencies": {
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        }
       }
     },
     "coffeescript": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.3.1.tgz",
-      "integrity": "sha512-DNJmSPMyiz+OjWYyuDXNBcFutDjP2TS2owsZ8YvT65hA8c5IdHWIBqdA3Yf/XHoK23d/f1HqLjQbEJJZJoeV1w==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.3.2.tgz",
+      "integrity": "sha512-YObiFDoukx7qPBi/K0kUKyntEZDfBQiqs/DbrR1xzASKOBjGT7auD85/DiPeRr9k++lRj7l3uA9TNMLfyfcD/Q==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "color-name": "1.1.3"
       }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
-    },
-    "compressible": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
-      "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
-      "dev": true,
-      "requires": {
-        "mime-db": ">= 1.34.0 < 2"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.34.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.34.0.tgz",
-          "integrity": "sha1-RS0Oz/XDA0am3B5kseruDTcZ/5o=",
-          "dev": true
-        }
-      }
-    },
-    "compression": {
-      "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
-      "integrity": "sha1-sDuNhub4rSloPLqN+R3cb/x3s5U=",
-      "dev": true,
-      "requires": {
-        "accepts": "~1.2.12",
-        "bytes": "2.1.0",
-        "compressible": "~2.0.5",
-        "debug": "~2.2.0",
-        "on-headers": "~1.0.0",
-        "vary": "~1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1040,153 +976,19 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "connect": {
-      "version": "2.30.2",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
-      "integrity": "sha1-jam8vooFTT0xjXTf7JA7XDmhtgk=",
-      "dev": true,
-      "requires": {
-        "basic-auth-connect": "1.0.0",
-        "body-parser": "~1.13.3",
-        "bytes": "2.1.0",
-        "compression": "~1.5.2",
-        "connect-timeout": "~1.6.2",
-        "content-type": "~1.0.1",
-        "cookie": "0.1.3",
-        "cookie-parser": "~1.3.5",
-        "cookie-signature": "1.0.6",
-        "csurf": "~1.8.3",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "errorhandler": "~1.4.2",
-        "express-session": "~1.11.3",
-        "finalhandler": "0.4.0",
-        "fresh": "0.3.0",
-        "http-errors": "~1.3.1",
-        "method-override": "~2.3.5",
-        "morgan": "~1.6.1",
-        "multiparty": "3.3.2",
-        "on-headers": "~1.0.0",
-        "parseurl": "~1.3.0",
-        "pause": "0.1.0",
-        "qs": "4.0.0",
-        "response-time": "~2.3.1",
-        "serve-favicon": "~2.3.0",
-        "serve-index": "~1.7.2",
-        "serve-static": "~1.10.0",
-        "type-is": "~1.6.6",
-        "utils-merge": "1.0.0",
-        "vhost": "~3.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "connect-timeout": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
-      "integrity": "sha1-3ppexh4zoStu2qt7XwYumMWZuI4=",
-      "dev": true,
-      "requires": {
-        "debug": "~2.2.0",
-        "http-errors": "~1.3.1",
-        "ms": "0.7.1",
-        "on-headers": "~1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "content-disposition": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz",
-      "integrity": "sha1-QoT+auBjCHRjnkToCkGMKTQTXp4=",
-      "dev": true
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
-    },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
-    },
-    "cookie": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-      "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-      "dev": true
-    },
-    "cookie-parser": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
-      "integrity": "sha1-nXVVcPtdF4kHcSJ6AjFNm+fPg1Y=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "cookie": "0.1.3",
-        "cookie-signature": "1.0.6"
+        "safe-buffer": "~5.1.1"
       }
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
-    },
-    "cookiejar": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
-      "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4=",
-      "dev": true
     },
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
-    "crc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
-      "integrity": "sha1-+mIuG8OIvyVzCQgta2UgDOZwkLo=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+      "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
       "dev": true
     },
     "csextends": {
@@ -1196,16 +998,17 @@
       "dev": true
     },
     "cson": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cson/-/cson-3.0.2.tgz",
-      "integrity": "sha1-g+6Qids8JUvsHpjkmNmqzxGtzFQ=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cson/-/cson-5.1.0.tgz",
+      "integrity": "sha512-hh97pBcNEc24OQn+CBYu1pp9kcEqp3dE0oO52QIoQkDREnZYHUD1YcKcGvHU+k9lgCmIXHslJfGTie58zjhLnA==",
       "dev": true,
       "requires": {
-        "coffee-script": "^1.9.0",
-        "cson-parser": "^1.0.6",
-        "extract-opts": "^3.0.1",
-        "requirefresh": "^2.0.0",
-        "safefs": "^4.0.0"
+        "coffee-script": "^1.12.7",
+        "cson-parser": "^1.3.4",
+        "editions": "^1.3.3",
+        "extract-opts": "^3.3.1",
+        "requirefresh": "^2.1.0",
+        "safefs": "^4.1.0"
       },
       "dependencies": {
         "coffee-script": {
@@ -1213,22 +1016,12 @@
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
           "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
           "dev": true
-        },
-        "safefs": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
-          "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "graceful-fs": "^4.1.4"
-          }
         }
       }
     },
     "cson-parser": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
+      "resolved": "http://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
       "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
       "dev": true,
       "requires": {
@@ -1243,36 +1036,13 @@
         }
       }
     },
-    "csrf": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
-      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+    "d": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "rndm": "1.2.0",
-        "tsscmp": "1.0.5",
-        "uid-safe": "2.1.4"
-      }
-    },
-    "csurf": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
-      "integrity": "sha1-I/KhO/HY/OHQyZZYg5RELLqGpWo=",
-      "dev": true,
-      "requires": {
-        "cookie": "0.1.3",
-        "cookie-signature": "1.0.6",
-        "csrf": "~3.0.0",
-        "http-errors": "~1.3.1"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
+        "es5-ext": "^0.10.9"
       }
     },
     "debug": {
@@ -1284,24 +1054,6 @@
         "ms": "2.0.0"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "depd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-      "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=",
-      "dev": true
-    },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
-    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -1311,81 +1063,150 @@
         "repeating": "^2.0.0"
       }
     },
-    "docpad": {
-      "version": "6.79.4",
-      "resolved": "https://registry.npmjs.org/docpad/-/docpad-6.79.4.tgz",
-      "integrity": "sha1-goysmMHnLbuVZKsOqhPJmm9ePds=",
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "docmatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/docmatter/-/docmatter-1.0.0.tgz",
+      "integrity": "sha512-cO1WhYDiFf8VPLG3R7tvZn7Y81enf/2VERD9i0CnLxQJHd84ae3YCpNUwI7o62WvER9LA+CNn5Tbz3+ocwwKxQ==",
       "dev": true,
       "requires": {
-        "ambi": "^2.2.0",
-        "backbone": "1.2.3",
-        "bal-util": "~2.5.1",
-        "caterpillar": "^2.0.9",
-        "caterpillar-filter": "^2.0.3",
-        "caterpillar-human": "^2.1.1",
-        "commander": "^2.7.1",
-        "csextends": "^1.0.3",
-        "cson": "^3.0.1",
-        "eachr": "^2.0.2",
-        "encoding": "~0.1.11",
-        "envfile": "^1.0.0",
-        "event-emitter-grouped": "2.4.3",
-        "express": "^3.21.2",
-        "extendr": "^2.1.0",
-        "extract-opts": "^3.0.1",
-        "getmac": "^1.0.6",
-        "hostenv": "^1.0.3",
-        "ignorefs": "^1.0.0",
-        "istextorbinary": "^1.0.0",
-        "jschardet": "~1.3.0",
-        "lazy-require": "^2.0.0",
-        "method-override": "^2.3.2",
-        "mime": "^1.3.4",
-        "progressbar": "^1.0.3",
-        "promptly": "~0.2.1",
-        "query-engine": "~1.5.5",
-        "rimraf": "^2.2.8",
-        "safefs": "^3.1.2",
-        "safeps": "^5.1.0",
-        "scandirectory": "^2.5.0",
-        "semver": "^5.0.1",
-        "superagent": "^1.1.0",
-        "taskgroup": "^4.2.1",
-        "typechecker": "^2.0.8",
-        "underscore": "^1.8.2",
-        "watchr": "^2.4.13",
-        "yamljs": "~0.2.1"
+        "editions": "^1.3.4"
+      }
+    },
+    "docpad": {
+      "version": "6.82.5",
+      "resolved": "https://registry.npmjs.org/docpad/-/docpad-6.82.5.tgz",
+      "integrity": "sha512-U5M7ivGrOq1mjut9hCMVjk09qoYCrKbXNxdyLmGbpNGRu4k/5O9ywMNh+CxSIU3Di2s43s5zke9w2yoPcii+5w==",
+      "dev": true,
+      "requires": {
+        "@bevry/pluginloader": "^1.1.1",
+        "ambi": "^3.1.1",
+        "ansistyles": "^0.1.3",
+        "backbone": "1.3.3",
+        "bal-util": "~2.8.0",
+        "cac": "^5.0.11",
+        "caterpillar": "^3.1.2",
+        "caterpillar-filter": "^3.0.0",
+        "caterpillar-human": "^3.0.0",
+        "core-js": "^2.5.7",
+        "cson": "^5.1.0",
+        "docmatter": "^1.0.0",
+        "docpad-baseplugin": "^1.0.3",
+        "eachr": "^3.2.0",
+        "editions": "^2.0.2",
+        "encoding": "~0.1.12",
+        "envfile": "^2.3.0",
+        "errlop": "^1.0.3",
+        "event-emitter-grouped": "^2.7.1",
+        "extendr": "^3.3.0",
+        "extract-opts": "^3.3.1",
+        "ignorefs": "^1.2.0",
+        "inquirer": "^6.2.0",
+        "istextorbinary": "^2.2.1",
+        "jschardet": "~1.6.0",
+        "lazy-require": "^2.2.0",
+        "mime": "^2.3.1",
+        "node-fetch": "^2.2.0",
+        "progress-title": "^1.1.0",
+        "query-engine": "~1.5.7",
+        "rfc-log-levels": "^1.1.0",
+        "rimraf": "^2.6.2",
+        "safefs": "^4.1.0",
+        "safeps": "^7.0.1",
+        "scandirectory": "^3.0.1",
+        "semver": "^5.5.1",
+        "taskgroup": "^5.3.0",
+        "typechecker": "^4.6.0",
+        "unbounded": "^1.1.0",
+        "underscore": "^1.9.1",
+        "watchr": "^4.0.1",
+        "yamljs": "~0.3.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
+          }
+        }
+      }
+    },
+    "docpad-baseplugin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/docpad-baseplugin/-/docpad-baseplugin-1.0.3.tgz",
+      "integrity": "sha512-CsUeQCvIuEfMBhlwea83G9QhLRpQaxWk7pLljUl4yFOsvIWB0J0YbjFXuEmCCC5FUZcAdBwtQJSIR8MKYZVtZg==",
+      "dev": true,
+      "requires": {
+        "eachr": "^3.2.0",
+        "editions": "^2.0.2",
+        "errlop": "^1.0.3",
+        "extendr": "^3.3.0",
+        "typechecker": "^4.5.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
+          }
+        }
+      }
+    },
+    "docpad-plugintester": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/docpad-plugintester/-/docpad-plugintester-1.3.3.tgz",
+      "integrity": "sha512-+SOgo/eRP6nm6gtHhxyCT1burnFllc0s0Dvq0EK9yVOTkVGoSIO2jUNyNCsg2dJJNnS7dnFIYnCYYI2+4nlvMQ==",
+      "dev": true,
+      "requires": {
+        "assert-helpers": "^4.5.1",
+        "bal-util": "^2.8.0",
+        "editions": "^2.0.2",
+        "extendr": "^3.3.0",
+        "joe": "^2.0.2",
+        "joe-reporter-console": "^2.0.2",
+        "safefs": "^4.1.0",
+        "underscore": "^1.9.1"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
+          }
+        }
       }
     },
     "eachr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.4.tgz",
-      "integrity": "sha1-Rm98qhBwj2EFCeMsgHqv5X/BIr8=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
+      "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
       "dev": true,
       "requires": {
-        "typechecker": "^2.0.8"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "~0.1.0"
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
       }
     },
     "editions": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
       "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
     },
     "encoding": {
       "version": "0.1.12",
@@ -1397,61 +1218,87 @@
       }
     },
     "envfile": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/envfile/-/envfile-1.0.0.tgz",
-      "integrity": "sha1-MIhNmOH2rzExGE4EHc/fagK1Dq8=",
-      "dev": true
-    },
-    "errorhandler": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
-      "integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/envfile/-/envfile-2.3.0.tgz",
+      "integrity": "sha512-xcwno0xGhSVhgBfFx9SxwYd6FNfTdq8SMFjrQ4FYsxYUNQMPJTXn7dERrX439F1V4Ukk9x/nL/5GcNZaIVUT7g==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.0",
-        "escape-html": "~1.0.3"
+        "ambi": "^2.4.0",
+        "eachr": "^3.1.0",
+        "editions": "^1.3.3",
+        "typechecker": "^4.0.1"
       },
       "dependencies": {
-        "accepts": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+        "ambi": {
+          "version": "2.5.0",
+          "resolved": "http://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
+          "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
           "dev": true,
           "requires": {
-            "mime-types": "~2.1.18",
-            "negotiator": "0.6.1"
+            "editions": "^1.1.1",
+            "typechecker": "^4.3.0"
           }
-        },
-        "escape-html": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true
-        },
-        "negotiator": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "dev": true
         }
       }
     },
-    "escape-html": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-      "integrity": "sha1-130y+pjjjC9BroXpJ44ODmuhAiw=",
-      "dev": true
+    "errlop": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.0.3.tgz",
+      "integrity": "sha512-5VTnt0yikY4LlQEfCXVSqfE6oLj1HVM4zVSvAKMnoYjL/zrb6nqiLowZS4XlG7xENfyj7lpYWvT+wfSCr6dtlA==",
+      "dev": true,
+      "requires": {
+        "editions": "^1.3.4"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.46",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esutils": {
@@ -1460,155 +1307,71 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "etag": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-      "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
-      "dev": true
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "event-emitter-grouped": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/event-emitter-grouped/-/event-emitter-grouped-2.4.3.tgz",
-      "integrity": "sha1-o5kTiVnflbrLczdgbQCYyVw1KhU=",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/event-emitter-grouped/-/event-emitter-grouped-2.7.1.tgz",
+      "integrity": "sha512-SKeWdzwPRyUTkc6ixmnTwLXqYX4LdpKSNliqm95NxUxzwsT+Bu+eEmgalRajPY5SHcbOG/9UHHao8+p5BI3uQA==",
       "dev": true,
       "requires": {
-        "ambi": "~2.2.0",
-        "taskgroup": "^4.0.0"
+        "editions": "^2.0.2",
+        "taskgroup": "^5.0.0",
+        "unbounded": "^1.1.0"
       },
       "dependencies": {
-        "ambi": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.2.0.tgz",
-          "integrity": "sha1-L0O5EvujbJKIAvoiOilv/9b0Rm4=",
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
           "dev": true,
           "requires": {
-            "typechecker": "~2.0.7"
-          }
-        },
-        "typechecker": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-          "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4=",
-          "dev": true
-        }
-      }
-    },
-    "express": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-3.21.2.tgz",
-      "integrity": "sha1-DCkD7lxU5j1lqWFwdkcDVQZlo94=",
-      "dev": true,
-      "requires": {
-        "basic-auth": "~1.0.3",
-        "commander": "2.6.0",
-        "connect": "2.30.2",
-        "content-disposition": "0.5.0",
-        "content-type": "~1.0.1",
-        "cookie": "0.1.3",
-        "cookie-signature": "1.0.6",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "escape-html": "1.0.2",
-        "etag": "~1.7.0",
-        "fresh": "0.3.0",
-        "merge-descriptors": "1.0.0",
-        "methods": "~1.1.1",
-        "mkdirp": "0.5.1",
-        "parseurl": "~1.3.0",
-        "proxy-addr": "~1.0.8",
-        "range-parser": "~1.0.2",
-        "send": "0.13.0",
-        "utils-merge": "1.0.0",
-        "vary": "~1.0.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-          "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "express-session": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
-      "integrity": "sha1-XMmPP1/4Ttg1+Ry/CqvQxxB0AK8=",
-      "dev": true,
-      "requires": {
-        "cookie": "0.1.3",
-        "cookie-signature": "1.0.6",
-        "crc": "3.3.0",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "on-headers": "~1.0.0",
-        "parseurl": "~1.3.0",
-        "uid-safe": "~2.0.0",
-        "utils-merge": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "uid-safe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
-          "integrity": "sha1-p/PGymSh9qXQTsDvPkw9U2cxcTc=",
-          "dev": true,
-          "requires": {
-            "base64-url": "1.2.1"
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
           }
         }
       }
-    },
-    "extend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-      "dev": true
     },
     "extendr": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.1.0.tgz",
-      "integrity": "sha1-MBqgu+pWX00tyPVw8qImEahSe1Y=",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/extendr/-/extendr-3.4.1.tgz",
+      "integrity": "sha512-xcdwhNFctt6U7XVBYgB35YG/CZFOZUZw+OCNiMPsgbENLlajgrZLVV6bgS/9zLHnY7s5nW6nJZcNrBvq033l1w==",
       "dev": true,
       "requires": {
-        "typechecker": "~2.0.1"
+        "editions": "^2.1.0",
+        "typechecker": "^4.7.0"
       },
       "dependencies": {
-        "typechecker": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-          "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4=",
-          "dev": true
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
+          }
         }
+      }
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "extract-opts": {
@@ -1620,173 +1383,6 @@
         "eachr": "^3.2.0",
         "editions": "^1.1.1",
         "typechecker": "^4.3.0"
-      },
-      "dependencies": {
-        "eachr": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
-          "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "typechecker": "^4.3.0"
-          }
-        },
-        "typechecker": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz",
-          "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.4"
-          }
-        }
-      }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
-    "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
-    "feedr": {
-      "version": "2.13.5",
-      "resolved": "https://registry.npmjs.org/feedr/-/feedr-2.13.5.tgz",
-      "integrity": "sha1-Wr26NAH2c0JlccT8PiOMFmvsey0=",
-      "dev": true,
-      "requires": {
-        "cson": "^4.0.0",
-        "eachr": "^3.2.0",
-        "editions": "^1.3.3",
-        "extendr": "^3.2.2",
-        "istextorbinary": "^2.1.0",
-        "js-yaml": "^3.8.1",
-        "request": "^2.79.0",
-        "safefs": "^4.1.0",
-        "safeps": "^6.3.0",
-        "taskgroup": "^5.0.1",
-        "typechecker": "^4.4.1",
-        "xml2js": "~0.4.17"
-      },
-      "dependencies": {
-        "binaryextensions": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
-          "integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==",
-          "dev": true
-        },
-        "coffee-script": {
-          "version": "1.12.7",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-          "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
-          "dev": true
-        },
-        "cson": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cson/-/cson-4.1.0.tgz",
-          "integrity": "sha1-sQdTRPqdn+XPiNgPIdk2Ypa4Zcc=",
-          "dev": true,
-          "requires": {
-            "coffee-script": "^1.12.4",
-            "cson-parser": "^1.3.4",
-            "extract-opts": "^3.3.1",
-            "requirefresh": "^2.1.0",
-            "safefs": "^4.1.0"
-          }
-        },
-        "eachr": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
-          "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "typechecker": "^4.3.0"
-          }
-        },
-        "extendr": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/extendr/-/extendr-3.3.0.tgz",
-          "integrity": "sha512-BmBSu+KOX2XOo3XMECiekGY8VAr3O4aGYgOaHQDNg2ez5rOYW+SDfNStao4VNzr+6N27Vw3A7HJKJMrHmAAXvQ==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.3",
-            "typechecker": "^4.4.1"
-          }
-        },
-        "istextorbinary": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
-          "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "2",
-            "editions": "^1.3.3",
-            "textextensions": "2"
-          }
-        },
-        "safefs": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
-          "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "graceful-fs": "^4.1.4"
-          }
-        },
-        "safeps": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/safeps/-/safeps-6.4.0.tgz",
-          "integrity": "sha1-s2Kxfd5GVS9xtn1nW1GQKHz3tjw=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.3",
-            "extract-opts": "^3.3.1",
-            "safefs": "^4.1.0",
-            "taskgroup": "^5.0.0",
-            "typechecker": "^4.3.0"
-          }
-        },
-        "taskgroup": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-5.0.1.tgz",
-          "integrity": "sha1-CHNsmyRoOxQ0d0Ix60tzqnw/ebU=",
-          "dev": true,
-          "requires": {
-            "ambi": "^2.5.0",
-            "eachr": "^3.2.0",
-            "editions": "^1.1.1",
-            "extendr": "^3.2.0"
-          }
-        },
-        "textextensions": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
-          "integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA==",
-          "dev": true
-        },
-        "typechecker": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz",
-          "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.4"
-          }
-        }
       }
     },
     "fellow": {
@@ -1798,69 +1394,14 @@
         "editions": "^1.1.1"
       }
     },
-    "finalhandler": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
-      "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "debug": "~2.2.0",
-        "escape-html": "1.0.2",
-        "on-finished": "~2.3.0",
-        "unpipe": "~1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
+        "escape-string-regexp": "^1.0.5"
       }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "1.0.0-rc3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-      "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
-      "dev": true,
-      "requires": {
-        "async": "^1.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.3"
-      }
-    },
-    "formidable": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.16.tgz",
-      "integrity": "sha1-SRbP38TL7QILJXpqlQWpqzjCzQ4=",
-      "dev": true
-    },
-    "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-      "dev": true
-    },
-    "fresh": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1868,29 +1409,16 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "getmac": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/getmac/-/getmac-1.4.3.tgz",
-      "integrity": "sha512-bOZafIX+19cCS5KUjHtlJPZW+4joMa5tISIk5CugjmlZE0zZtjwB59wm56JPXVy5ELivw7g4Z9TEI0EDa2CSwQ==",
-      "dev": true,
-      "requires": {
-        "editions": "^1.3.4",
-        "extract-opts": "^3.2.0"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
+    "githubauthquerystring": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/githubauthquerystring/-/githubauthquerystring-1.0.0.tgz",
+      "integrity": "sha512-rbYERtA/5z7lYfO/BgW+y8TbdUKSucM7OeSSc6xztv0Tj99DNsDcW5KngivOtp3KYOO/U4UbmVvvXyLjGWmlVg==",
+      "dev": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1908,44 +1436,18 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "handlebars": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
       "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
       "requires": {
         "optimist": "~0.3",
         "uglify-js": "~2.3"
-      },
-      "dependencies": {
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "requires": {
-            "wordwrap": "~0.0.2"
-          }
-        }
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true,
-      "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -1957,6 +1459,12 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -1967,37 +1475,10 @@
         "os-tmpdir": "^1.0.1"
       }
     },
-    "hostenv": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/hostenv/-/hostenv-1.0.5.tgz",
-      "integrity": "sha1-ZIH48QMVVfR2PfKC2HRIuScMOBI=",
-      "dev": true
-    },
-    "http-errors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-      "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.1",
-        "statuses": "1"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -2025,6 +1506,12 @@
       "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4=",
       "dev": true
     },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2041,6 +1528,73 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "inquirer": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -2049,12 +1603,6 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
-    },
-    "ipaddr.js": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
-      "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c=",
-      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2065,33 +1613,67 @@
         "number-is-nan": "^1.0.0"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "istextorbinary": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
-      "integrity": "sha1-rOGTVNGpoBc+/rEITOD4ewrX3s8=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.3.0.tgz",
+      "integrity": "sha512-xs+IFjzw1/5n45nMYUh2ipLWGarmE0bDVR85WAiYUXzawc8NYn1WW0qaq2rSEFIR3NoNkaAvOr3FVMojFz5uUg==",
       "dev": true,
       "requires": {
-        "binaryextensions": "~1.0.0",
-        "textextensions": "~1.0.0"
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.0.2",
+        "textextensions": "^2.4.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
+          }
+        }
       }
+    },
+    "joe": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npmjs.org/joe/-/joe-2.0.2.tgz",
+      "integrity": "sha1-iHTrV9w+tDFVj37RX9VYBdDvb08=",
+      "dev": true,
+      "requires": {
+        "editions": "^1.3.1",
+        "event-emitter-grouped": "^2.5.0",
+        "taskgroup": "^5.0.1"
+      }
+    },
+    "joe-reporter-console": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/joe-reporter-console/-/joe-reporter-console-2.0.2.tgz",
+      "integrity": "sha512-M/TWzAj8oKWv34vBd9VaRhi7ueE9wiui6M4D+wRGrh+zzH5FOXWIFFV+1S7q3XQxAeC2A5euSIKgc1bmhboQ/g==",
+      "dev": true,
+      "requires": {
+        "cli-color": "^1.1.0",
+        "editions": "^1.3.4"
+      }
+    },
+    "joycon": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.2.tgz",
+      "integrity": "sha512-pHMuJBQlVsaTc75MpaaLD9IdsMbs7J7hmqrOZH5ranw77feiqQANGZsabN0DoM8hv2ZIwqokJU6Tt/UyzaCPfQ==",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -2099,70 +1681,23 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
-    "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
-    },
     "jschardet": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.3.0.tgz",
-      "integrity": "sha1-dAxynak2L45cfm3P0cxq8TLvAo0=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
       "dev": true
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
     },
     "lazy-require": {
       "version": "2.2.0",
@@ -2175,36 +1710,6 @@
         "safeps": "^6.0.2"
       },
       "dependencies": {
-        "eachr": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
-          "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "typechecker": "^4.3.0"
-          }
-        },
-        "extendr": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/extendr/-/extendr-3.3.0.tgz",
-          "integrity": "sha512-BmBSu+KOX2XOo3XMECiekGY8VAr3O4aGYgOaHQDNg2ez5rOYW+SDfNStao4VNzr+6N27Vw3A7HJKJMrHmAAXvQ==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.3",
-            "typechecker": "^4.4.1"
-          }
-        },
-        "safefs": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
-          "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "graceful-fs": "^4.1.4"
-          }
-        },
         "safeps": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/safeps/-/safeps-6.4.0.tgz",
@@ -2217,103 +1722,62 @@
             "taskgroup": "^5.0.0",
             "typechecker": "^4.3.0"
           }
-        },
-        "taskgroup": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-5.0.1.tgz",
-          "integrity": "sha1-CHNsmyRoOxQ0d0Ix60tzqnw/ebU=",
-          "dev": true,
-          "requires": {
-            "ambi": "^2.5.0",
-            "eachr": "^3.2.0",
-            "editions": "^1.1.1",
-            "extendr": "^3.2.0"
-          }
-        },
-        "typechecker": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz",
-          "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.4"
-          }
         }
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
-    },
-    "merge-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz",
-      "integrity": "sha1-IWnPdTjhsMyH+4jhUC2EdLv3mGQ=",
-      "dev": true
-    },
-    "method-override": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz",
-      "integrity": "sha1-49r41d7hDdLc59SuiNYrvud0drQ=",
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "debug": "2.6.9",
-        "methods": "~1.1.2",
-        "parseurl": "~1.3.2",
-        "vary": "~1.1.2"
-      },
-      "dependencies": {
-        "vary": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true
-        }
+        "es5-ext": "~0.10.2"
       }
     },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+    "memoizee": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
+      }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
       "dev": true
     },
-    "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-      "dev": true,
-      "requires": {
-        "mime-db": "~1.33.0"
-      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2326,47 +1790,35 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "minimost": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimost/-/minimost-1.2.0.tgz",
+      "integrity": "sha512-/+eWyOtXw41WIUV9rBgrXna11bxbqymebSeW2arsfp/MCGCwe+2czzsOueEtLZgH4xb4QXhje5H9MLCsCPibLA==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
-      }
-    },
-    "morgan": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
-      "integrity": "sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=",
-      "dev": true,
-      "requires": {
-        "basic-auth": "~1.0.3",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
       }
     },
     "ms": {
@@ -2375,53 +1827,28 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "multiparty": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
-      "integrity": "sha1-Nd5oBNwZZD5SSfPT473GyM4wHT8=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.1.9",
-        "stream-counter": "~0.2.0"
-      }
-    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "negotiator": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-      "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g=",
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
-    },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
-      "requires": {
-        "ee-first": "1.1.1"
-      }
-    },
-    "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
       "dev": true
     },
     "once": {
@@ -2433,50 +1860,39 @@
         "wrappy": "1"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+      "requires": {
         "wordwrap": "~0.0.2"
       }
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "pause": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
-      "integrity": "sha1-68ikqGGf8LioGsFRPDQ0/0af23Q=",
-      "dev": true
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "private": {
@@ -2485,182 +1901,38 @@
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
-    "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-      "dev": true
-    },
-    "progressbar": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/progressbar/-/progressbar-1.3.0.tgz",
-      "integrity": "sha512-lOncE1DwVI/ioINInGrR0hsFG8I82H9RzMY1bghVAhoU3f+S/JurtfFLpNoEZTnjQ5FS9ZpHSoeZlxig8uyJtw==",
+    "progress-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-title/-/progress-title-1.1.0.tgz",
+      "integrity": "sha512-asOuNop2jgprbPzeUCKwcJwNgSVxbn40ALljG4xn8GTUtdsvatzA86Pw9tYGB+sWfCu3XcFEx95PRuW5j+vhsw==",
       "dev": true,
       "requires": {
-        "editions": "^1.3.3",
-        "progress": "2.0.0"
+        "editions": "^1.3.4"
       }
     },
     "projectz": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/projectz/-/projectz-1.4.0.tgz",
-      "integrity": "sha1-Iq3X40bb+3BMjsHrK0PTbts2AlA=",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/projectz/-/projectz-1.5.3.tgz",
+      "integrity": "sha512-Q+9N26VAgapKHx3rnACpldjXddKC9vzWue3vkmVSsUgYm+plwvqPC3+Wu3t0nVplRvI/WKanC65F2WmVVWxC1Q==",
       "dev": true,
       "requires": {
-        "badges": "^1.2.4",
-        "caterpillar": "^3.0.1",
+        "badges": "^1.2.8",
+        "caterpillar": "^3.1.2",
         "caterpillar-filter": "^3.0.0",
         "caterpillar-human": "^3.0.0",
-        "chainy-core": "^1.6.0",
-        "chainy-plugin-each": "^1.1.0",
-        "chainy-plugin-feed": "^1.0.0",
-        "chainy-plugin-map": "^1.0.5",
-        "chainy-plugin-set": "^1.0.2",
-        "commander": "^2.9.0",
-        "cson": "^4.0.0",
+        "commander": "^2.19.0",
+        "cson": "^5.1.0",
         "eachr": "^3.2.0",
-        "editions": "^1.3.3",
-        "extendr": "^3.2.2",
+        "extendr": "^3.3.0",
         "fellow": "^2.3.0",
+        "githubauthquerystring": "1.0.0",
+        "node-fetch": "^2.3.0",
         "safefs": "^4.1.0",
-        "spdx": "^0.5.1",
-        "spdx-license-list": "^3.0.1",
+        "spdx": "^0.5.2",
+        "spdx-license-list": "^5.0.0",
         "taskgroup": "5",
-        "typechecker": "^4.4.1"
-      },
-      "dependencies": {
-        "caterpillar": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/caterpillar/-/caterpillar-3.0.1.tgz",
-          "integrity": "sha1-RUZagV/tAe8RLGj89Dp+bdO8Gbo=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "extendr": "^3.2.0"
-          }
-        },
-        "caterpillar-filter": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/caterpillar-filter/-/caterpillar-filter-3.0.0.tgz",
-          "integrity": "sha1-WDOMJpwhB0AmuAPQUmi0DwL52IE=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1"
-          }
-        },
-        "caterpillar-human": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/caterpillar-human/-/caterpillar-human-3.0.0.tgz",
-          "integrity": "sha1-PcytsXL7fuifjSo1skdc0/FaFXo=",
-          "dev": true,
-          "requires": {
-            "ansicolors": "~0.3.2",
-            "ansistyles": "~0.1.3",
-            "editions": "^1.1.1"
-          }
-        },
-        "coffee-script": {
-          "version": "1.12.7",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-          "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
-          "dev": true
-        },
-        "cson": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cson/-/cson-4.1.0.tgz",
-          "integrity": "sha1-sQdTRPqdn+XPiNgPIdk2Ypa4Zcc=",
-          "dev": true,
-          "requires": {
-            "coffee-script": "^1.12.4",
-            "cson-parser": "^1.3.4",
-            "extract-opts": "^3.3.1",
-            "requirefresh": "^2.1.0",
-            "safefs": "^4.1.0"
-          }
-        },
-        "eachr": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
-          "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "typechecker": "^4.3.0"
-          }
-        },
-        "extendr": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/extendr/-/extendr-3.3.0.tgz",
-          "integrity": "sha512-BmBSu+KOX2XOo3XMECiekGY8VAr3O4aGYgOaHQDNg2ez5rOYW+SDfNStao4VNzr+6N27Vw3A7HJKJMrHmAAXvQ==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.3",
-            "typechecker": "^4.4.1"
-          }
-        },
-        "safefs": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
-          "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "graceful-fs": "^4.1.4"
-          }
-        },
-        "taskgroup": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-5.0.1.tgz",
-          "integrity": "sha1-CHNsmyRoOxQ0d0Ix60tzqnw/ebU=",
-          "dev": true,
-          "requires": {
-            "ambi": "^2.5.0",
-            "eachr": "^3.2.0",
-            "editions": "^1.1.1",
-            "extendr": "^3.2.0"
-          }
-        },
-        "typechecker": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz",
-          "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.4"
-          }
-        }
+        "typechecker": "^4.6.0"
       }
-    },
-    "promptly": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.1.tgz",
-      "integrity": "sha1-ZETnyk29mJnn7rXsOSKCfr3CKzs=",
-      "dev": true,
-      "requires": {
-        "read": "~1.0.4"
-      }
-    },
-    "proxy-addr": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
-      "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
-      "dev": true,
-      "requires": {
-        "forwarded": "~0.1.0",
-        "ipaddr.js": "1.0.5"
-      }
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
-    },
-    "qs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-      "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
-      "dev": true
     },
     "query-engine": {
       "version": "1.5.7",
@@ -2668,69 +1940,24 @@
       "integrity": "sha1-AepGbRPBxXA0OxfXAGy6bhw6ars=",
       "dev": true
     },
-    "random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
-      "dev": true
-    },
-    "range-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-      "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU=",
-      "dev": true
-    },
-    "raw-body": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-      "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+    "readdir-cluster": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-cluster/-/readdir-cluster-1.1.0.tgz",
+      "integrity": "sha1-sNOxpzPBE0V7ThrYmR/fgagXSnc=",
       "dev": true,
       "requires": {
-        "bytes": "2.4.0",
-        "iconv-lite": "0.4.13",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-          "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-          "dev": true
-        }
+        "editions": "^1.1.1"
       }
     },
-    "read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
-        "mute-stream": "~0.0.4"
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
       }
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "reduce-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
-      "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
-      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",
@@ -2757,7 +1984,7 @@
     },
     "regexpu-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
@@ -2768,13 +1995,13 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
@@ -2783,7 +2010,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -2798,59 +2025,6 @@
         "is-finite": "^1.0.0"
       }
     },
-    "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
-      },
-      "dependencies": {
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
-        }
-      }
-    },
     "requirefresh": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-2.1.0.tgz",
@@ -2862,27 +2036,25 @@
     },
     "resolve": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
       "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
       "dev": true
     },
-    "response-time": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
-      "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.0",
-        "on-headers": "~1.0.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
-        }
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
+    },
+    "rfc-log-levels": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rfc-log-levels/-/rfc-log-levels-1.1.0.tgz",
+      "integrity": "sha512-GFN9gTsQxHSs4PitqsnYO036weay+K7f2gQ3yj5KilKkeZhEDugAKvak1AyMfdae/LlgjcgZjPxL0inPEXueRA==",
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.2",
@@ -2893,11 +2065,23 @@
         "glob": "^7.0.5"
       }
     },
-    "rndm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
-      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w=",
-      "dev": true
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -2906,24 +2090,26 @@
       "dev": true
     },
     "safefs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/safefs/-/safefs-3.2.2.tgz",
-      "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
+      "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
       "dev": true,
       "requires": {
-        "graceful-fs": "*"
+        "editions": "^1.1.1",
+        "graceful-fs": "^4.1.4"
       }
     },
     "safeps": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/safeps/-/safeps-5.1.0.tgz",
-      "integrity": "sha1-iyyRBCkqaaIWhzY/BWpQCRYZK2s=",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/safeps/-/safeps-7.0.1.tgz",
+      "integrity": "sha1-FXPMsJy/AeAckFIr68bIsicL8hk=",
       "dev": true,
       "requires": {
-        "extract-opts": "^3.0.1",
-        "safefs": "^3.1.3",
-        "taskgroup": "^4.3.0",
-        "typechecker": "^2.0.8"
+        "editions": "^1.3.3",
+        "extract-opts": "^3.3.1",
+        "safefs": "^4.1.0",
+        "taskgroup": "^5.0.0",
+        "typechecker": "^4.3.0"
       }
     },
     "safer-buffer": {
@@ -2932,213 +2118,28 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
     "scandirectory": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-2.5.0.tgz",
-      "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-3.0.1.tgz",
+      "integrity": "sha1-Jd0gFCfDPM5Pj0Cy838tA9B4V7o=",
       "dev": true,
       "requires": {
-        "ignorefs": "^1.0.0",
-        "safefs": "^3.1.2",
-        "taskgroup": "^4.0.5"
+        "editions": "^1.3.1",
+        "ignorefs": "^1.1.1",
+        "readdir-cluster": "^1.1.0"
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
     },
-    "send": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
-      "integrity": "sha1-UY+SGusFYK7H3KspkLFM9vPM5d4=",
-      "dev": true,
-      "requires": {
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "destroy": "1.0.3",
-        "escape-html": "1.0.2",
-        "etag": "~1.7.0",
-        "fresh": "0.3.0",
-        "http-errors": "~1.3.1",
-        "mime": "1.3.4",
-        "ms": "0.7.1",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.0.2",
-        "statuses": "~1.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "destroy": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
-          "integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk=",
-          "dev": true
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg=",
-          "dev": true
-        }
-      }
-    },
-    "serve-favicon": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
-      "integrity": "sha1-3UGeJo3gEqtysxnTN/IQUBP5OB8=",
-      "dev": true,
-      "requires": {
-        "etag": "~1.7.0",
-        "fresh": "0.3.0",
-        "ms": "0.7.2",
-        "parseurl": "~1.3.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
-      }
-    },
-    "serve-index": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
-      "integrity": "sha1-egV/xu4o3GP2RWbl+lexEahq7NI=",
-      "dev": true,
-      "requires": {
-        "accepts": "~1.2.13",
-        "batch": "0.5.3",
-        "debug": "~2.2.0",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.3.1",
-        "mime-types": "~2.1.9",
-        "parseurl": "~1.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "escape-html": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "serve-static": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
-      "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
-      "dev": true,
-      "requires": {
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.1",
-        "send": "0.13.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
-        },
-        "escape-html": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "send": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
-          "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
-          "dev": true,
-          "requires": {
-            "debug": "~2.2.0",
-            "depd": "~1.1.0",
-            "destroy": "~1.0.4",
-            "escape-html": "~1.0.3",
-            "etag": "~1.7.0",
-            "fresh": "0.3.0",
-            "http-errors": "~1.3.1",
-            "mime": "1.3.4",
-            "ms": "0.7.1",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.0.3",
-            "statuses": "~1.2.1"
-          }
-        },
-        "statuses": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg=",
-          "dev": true
-        }
-      }
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",
@@ -3147,10 +2148,13 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "version": "0.1.43",
+      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "optional": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
     },
     "source-map-support": {
       "version": "0.4.18",
@@ -3159,12 +2163,20 @@
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "spdx": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/spdx/-/spdx-0.5.1.tgz",
-      "integrity": "sha1-02wnUIi0jXWpBGzUSoOM5LUzmZg=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/spdx/-/spdx-0.5.2.tgz",
+      "integrity": "sha512-WQbfCQT2uKLsDllnO9ItpcGUiiF1O/ZvBGCyqFZRg122HgiZubpwpZiM7BkmH19HC3XR3Z+DFMGJNzXSPebG8A==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^1.0.0",
@@ -3173,125 +2185,75 @@
     },
     "spdx-exceptions": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz",
+      "resolved": "http://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz",
       "integrity": "sha1-nSGsTaS9tx0GD7dOWmdTHQMsu6Y=",
       "dev": true
     },
     "spdx-license-ids": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
     "spdx-license-list": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-3.0.1.tgz",
-      "integrity": "sha1-Fj1yEj4A9Pi9bhgSVpawCfEkj/U=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-5.0.0.tgz",
+      "integrity": "sha512-N5u9tEFRBUzQDjMKRRt8SHxC/UaqYApPmdF4MMFnICQg3z52onNbnneuro/sWw2rd+eGu9agQOzUbD671Xia7Q==",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
-    },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
-    },
-    "stream-counter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
-      "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.1.8"
-      }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
-    },
-    "superagent": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.5.tgz",
-      "integrity": "sha1-HA3cOvMOgOuE68BcshItqP6UC1U=",
-      "dev": true,
-      "requires": {
-        "component-emitter": "~1.2.0",
-        "cookiejar": "2.0.6",
-        "debug": "2",
-        "extend": "3.0.0",
-        "form-data": "1.0.0-rc3",
-        "formidable": "~1.0.14",
-        "methods": "~1.1.1",
-        "mime": "1.3.4",
-        "qs": "2.3.3",
-        "readable-stream": "1.0.27-1",
-        "reduce-component": "1.0.1"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        },
-        "qs": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.27-1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-          "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
-      }
     },
     "supports-color": {
       "version": "2.0.0",
@@ -3300,20 +2262,54 @@
       "dev": true
     },
     "taskgroup": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-4.3.1.tgz",
-      "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-5.3.0.tgz",
+      "integrity": "sha512-++j3Yi3XZGYgAvmGzRtNa+BnDvkPbdroyMffCY+Gj9A4iH2IJ1S7/g6LewGVXQkVw/KOzlfE1TimARYXvOEsgQ==",
       "dev": true,
       "requires": {
-        "ambi": "^2.2.0",
-        "csextends": "^1.0.3"
+        "ambi": "^3.0.0",
+        "eachr": "^3.2.0",
+        "editions": "^1.3.4",
+        "extendr": "^3.2.2",
+        "unbounded": "^1.1.0"
       }
     },
-    "textextensions": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz",
-      "integrity": "sha1-ZUhjk+4fK7A5pgy7oFsLaL2VAdI=",
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "textextensions": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
+      "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA==",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -3321,103 +2317,57 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dev": true,
-      "requires": {
-        "punycode": "^1.4.1"
-      }
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
-    "tsscmp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
-      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc=",
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
-    },
-    "type-is": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-      "dev": true,
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
-      }
     },
     "typechecker": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.1.0.tgz",
-      "integrity": "sha1-0cIJOlT/ihn1jP+HfuqlTyJC04M=",
-      "dev": true
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.7.0.tgz",
+      "integrity": "sha512-4LHc1KMNJ6NDGO+dSM/yNfZQRtp8NN7psYrPHUblD62Dvkwsp3VShsbM78kOgpcmMkRTgvwdKOTjctS+uMllgQ==",
+      "dev": true,
+      "requires": {
+        "editions": "^2.1.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
+          }
+        }
+      }
     },
     "uglify-js": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
       "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
       "optional": true,
       "requires": {
         "async": "~0.2.6",
         "optimist": "~0.3.5",
         "source-map": "~0.1.7"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "optional": true
-        },
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "optional": true,
-          "requires": {
-            "wordwrap": "~0.0.2"
-          }
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
       }
     },
-    "uid-safe": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-      "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
+    "unbounded": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbounded/-/unbounded-1.1.0.tgz",
+      "integrity": "sha512-kmPrjST7m53WbxoMqk6QUFvWOp/ZGssCA0Zls63pbt+7cZqST4i0YIVLNX97ZlsMv/ml+0CPBVN15sVdSi/yZA==",
       "dev": true,
       "requires": {
-        "random-bytes": "~1.0.0"
+        "editions": "^1.3.4"
       }
     },
     "underscore": {
@@ -3426,112 +2376,29 @@
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
       "dev": true
     },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
-    },
-    "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
-      "dev": true
-    },
-    "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "dev": true
-    },
-    "vary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-      "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA=",
-      "dev": true
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "vhost": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
-      "integrity": "sha1-L7HezUxGaqiLD5NBrzPcGv8keNU=",
-      "dev": true
-    },
     "watchr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/watchr/-/watchr-2.6.0.tgz",
-      "integrity": "sha1-51xCOxC+eSZ6DD73bi6hBP4CZ6U=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/watchr/-/watchr-4.1.0.tgz",
+      "integrity": "sha512-ShaYIRazXv+4FjHNcjd6H8oyWcJnLh3M7Gle/7ZVj8WoMqBXU0xotCwxPFjEe8j92nozdBz0Q2hOrnp+U+55FA==",
       "dev": true,
       "requires": {
         "eachr": "^3.2.0",
+        "editions": "^2.1.0",
         "extendr": "^3.2.2",
-        "extract-opts": "^3.3.1",
         "ignorefs": "^1.1.1",
         "safefs": "^4.1.0",
-        "scandirectory": "^2.5.0",
-        "taskgroup": "^5.0.1",
-        "typechecker": "^4.3.0"
+        "scandirectory": "^3.0.1",
+        "taskgroup": "^5.0.1"
       },
       "dependencies": {
-        "eachr": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
-          "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
+        "editions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+          "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
           "dev": true,
           "requires": {
-            "editions": "^1.1.1",
-            "typechecker": "^4.3.0"
-          }
-        },
-        "extendr": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/extendr/-/extendr-3.3.0.tgz",
-          "integrity": "sha512-BmBSu+KOX2XOo3XMECiekGY8VAr3O4aGYgOaHQDNg2ez5rOYW+SDfNStao4VNzr+6N27Vw3A7HJKJMrHmAAXvQ==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.3",
-            "typechecker": "^4.4.1"
-          }
-        },
-        "safefs": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
-          "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
-          "dev": true,
-          "requires": {
-            "editions": "^1.1.1",
-            "graceful-fs": "^4.1.4"
-          }
-        },
-        "taskgroup": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-5.0.1.tgz",
-          "integrity": "sha1-CHNsmyRoOxQ0d0Ix60tzqnw/ebU=",
-          "dev": true,
-          "requires": {
-            "ambi": "^2.5.0",
-            "eachr": "^3.2.0",
-            "editions": "^1.1.1",
-            "extendr": "^3.2.0"
-          }
-        },
-        "typechecker": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz",
-          "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
-          "dev": true,
-          "requires": {
-            "editions": "^1.3.4"
+            "errlop": "^1.0.3",
+            "semver": "^5.6.0"
           }
         }
       }
@@ -3547,26 +2414,10 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
-    },
     "yamljs": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.2.10.tgz",
-      "integrity": "sha1-SBzHwlynOvWfWR8MluPOVsdXpA8=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docpad-plugin-handlebars",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Adds support for the Handlebars templating engine to DocPad.",
   "homepage": "ssh://git@github.com/docpad/docpad-plugin-handlebars",
   "license": "MIT",
@@ -106,6 +106,7 @@
     "coffeelint": "^2.1.0",
     "coffeescript": "^2.3.1",
     "docpad": "^6.79.4",
+    "docpad-plugintester": "^1.3.3",
     "projectz": "^1.4.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "babel-preset-es2015": "^6.24.1",
     "coffeelint": "^2.1.0",
     "coffeescript": "^2.3.1",
-    "docpad": "^6.79.4",
+    "docpad": "^6.82.0",
     "docpad-plugintester": "^1.3.3",
     "projectz": "^1.4.0"
   },

--- a/source/handlebars.plugin.coffee
+++ b/source/handlebars.plugin.coffee
@@ -11,6 +11,8 @@ module.exports = (BasePlugin) ->
 
 		# Constructor
 		setConfig: (config) ->
+			# Super
+			super(config)
 			# Prepare
 			docpad = @docpad
 			handlebars = @handlebars = require('handlebars')
@@ -26,9 +28,6 @@ module.exports = (BasePlugin) ->
 			if @config.partials
 				for own name,partial of @config.partials
 					handlebars.registerPartial(name, partial)
-
-			# Chain
-			super(config)
 
 		# Render some content
 		render: (opts) ->

--- a/source/handlebars.test.coffee
+++ b/source/handlebars.test.coffee
@@ -1,5 +1,6 @@
 # Test our plugin using DocPad's Testers
-require('docpad').require('testers').test({
-	pluginPath: __dirname+'/..'
-	testerClass: 'RendererTester'
+
+require('docpad-plugintester').test({
+    DocPad: require('docpad'),
+    pluginPath: require('path').join(__dirname, '..')
 })


### PR DESCRIPTION
We've been trying to update some sites to use the 6.82.x line of DocPad and encountered difficulties with the Handlebars plug-in where it wasn't passing in the helpers or partials defined in our `docpad.js` file. 

I traced the errors and confirmed that they were present in this plug-in when using the 6.82.x line (tests failing with the same error log of missing helpers / partials).

This PR fixes the plug-in for the 6.82.x line by moving the call to `super(config)` from the bottom to the top of the plug-in's own `setConfig` method. This appears necessary to properly initialize the plug-in config to add the helpers and partials before the plugin tries to process them.

I'm far from an expert on Docpad's plugin architecture so this fix is at the level of "tests pass again, and fixes the problem for our sites", so please let me know if there's a better way to address this. I'm guessing the issue I've seen is related to this change to `docpad-baseplugin` that changes how config merging is handled: https://github.com/docpad/docpad-baseplugin/blob/master/HISTORY.md#v103-2018-september-7